### PR TITLE
Fix comment typo

### DIFF
--- a/test/list_test.rb
+++ b/test/list_test.rb
@@ -230,7 +230,7 @@ class ListTest < Test::Unit::TestCase
     assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
 
     # We need to trigger all the before_destroy callbacks without actually
-    # destroying the record so we can see the affect the callbacks have on
+    # destroying the record so we can see the effect the callbacks have on
     # the record.
     list = ListMixin.find(2)
     if list.respond_to?(:run_callbacks)


### PR DESCRIPTION
## Summary
- fix a typo in a comment of `test_before_destroy_callbacks_do_not_update_position_to_nil_before_deleting_the_record`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68781ea30f10832584da1b72f6569b08