### PR TITLE
Fix Rakefile description

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'rake/testtask'
 desc 'Default: run acts_as_list unit tests.'
 task :default => :test
 
-desc 'Test the acts_as_ordered_tree plugin.'
+desc 'Test the acts_as_list plugin.'
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.pattern = 'test/**/*_test.rb'


### PR DESCRIPTION
## Summary
- update the test description in the Rakefile to reference the acts_as_list plugin

## Testing
- `rake test` *(fails: Could not find 'sqlite3' >= 2.1 and errors in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68781ebc47bc83259b2448b9265cafe1