### PR TITLE
Fix test setup for newer Ruby

### DIFF
--- a/test/list_test.rb
+++ b/test/list_test.rb
@@ -1,7 +1,8 @@
 require 'test/unit'
 
 require 'rubygems'
-gem 'activerecord', '>= 1.15.4.7794'
+require 'logger'
+gem 'activerecord', '~> 6.1.7'
 require 'active_record'
 
 # Provide a backwards compatible +find+ API for tests running on modern Rails.


### PR DESCRIPTION
## Summary
- require the standard `logger` library in tests
- pin ActiveRecord version to 6.1.x for compatibility

## Testing
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_6878211ba4ec8325b0877b0c14e6c7c1