### PR TITLE
Add relative repositioning helpers

### DIFF
--- a/README
+++ b/README
@@ -18,6 +18,8 @@ Example
 
   todo_list.first.move_to_bottom
   todo_list.last.move_higher
+  todo_list.first.move_below(todo_list.last)
+  todo_list.last.move_above(todo_list.first)
 
 
 Copyright (c) 2007 David Heinemeier Hansson, released under the MIT license

--- a/lib/active_record/acts/list.rb
+++ b/lib/active_record/acts/list.rb
@@ -146,6 +146,20 @@ module ActiveRecord
           end
         end
 
+        # Move this item so it is immediately above +item+ in the list.
+        def move_above(item)
+          return unless item
+          insert_at(item.send(position_column) -
+                    (in_list? && self.send(position_column).to_i < item.send(position_column).to_i ? 1 : 0))
+        end
+
+        # Move this item so it is immediately below +item+ in the list.
+        def move_below(item)
+          return unless item
+          insert_at(item.send(position_column) +
+                    (in_list? && self.send(position_column).to_i > item.send(position_column).to_i ? 1 : 0))
+        end
+
         # Removes the item from the list.
         def remove_from_list
           if in_list?

--- a/test/list_test.rb
+++ b/test/list_test.rb
@@ -108,6 +108,18 @@ class ListTest < Test::Unit::TestCase
     assert_equal [1, 2, 4, 3], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
   end
 
+  def test_move_above
+    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+    ListMixin.find(4).move_above(ListMixin.find(2))
+    assert_equal [1, 4, 2, 3], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+  end
+
+  def test_move_below
+    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+    ListMixin.find(1).move_below(ListMixin.find(3))
+    assert_equal [2, 3, 1, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+  end
+
   def test_next_prev
     assert_equal ListMixin.find(2), ListMixin.find(1).lower_item
     assert_nil ListMixin.find(1).higher_item
@@ -304,6 +316,18 @@ class ListSubTest < Test::Unit::TestCase
     assert_equal [1, 2, 4, 3], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
   end
 
+  def test_move_above
+    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+    ListMixin.find(4).move_above(ListMixin.find(2))
+    assert_equal [1, 4, 2, 3], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+  end
+
+  def test_move_below
+    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+    ListMixin.find(1).move_below(ListMixin.find(3))
+    assert_equal [2, 3, 1, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+  end
+
   def test_next_prev
     assert_equal ListMixin.find(2), ListMixin.find(1).lower_item
     assert_nil ListMixin.find(1).higher_item
@@ -410,6 +434,18 @@ class ArrayScopeListTest < Test::Unit::TestCase
     assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
     ArrayScopeListMixin.find(3).move_to_bottom
     assert_equal [1, 2, 4, 3], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+  end
+
+  def test_move_above
+    assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+    ArrayScopeListMixin.find(4).move_above(ArrayScopeListMixin.find(2))
+    assert_equal [1, 4, 2, 3], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+  end
+
+  def test_move_below
+    assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+    ArrayScopeListMixin.find(1).move_below(ArrayScopeListMixin.find(3))
+    assert_equal [2, 3, 1, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
   end
 
   def test_next_prev


### PR DESCRIPTION
## Summary
- support placing one record above or below another
- document new helper methods
- test move_above and move_below across list implementations

## Testing
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_68782570b7608325a5b9eeeacec9a7c5