### PR TITLE
Add scope change handling

### DIFF
--- a/lib/active_record/acts/list.rb
+++ b/lib/active_record/acts/list.rb
@@ -80,6 +80,8 @@ module ActiveRecord
           class_eval <<-EOV
             include ActiveRecord::Acts::List::InstanceMethods
 
+            cattr_accessor :acts_as_list_options
+
             def acts_as_list_class
               ::#{self.name}
             end
@@ -92,7 +94,10 @@ module ActiveRecord
 
             before_destroy :decrement_positions_on_lower_items
             before_create  :add_to_list_bottom
+            before_update  :acts_as_list_handle_scope_change
+            after_update   :acts_as_list_restore_position
           EOV
+          self.acts_as_list_options = configuration
         end
       end
 
@@ -269,11 +274,66 @@ module ActiveRecord
           end
 
           # Increments position (<tt>position_column</tt>) of all items in the list.
-          def increment_positions_on_all_items
-            acts_as_list_class.where(
-              scope_condition
-            ).update_all("#{position_column} = (#{position_column} + 1)")
+        def increment_positions_on_all_items
+          acts_as_list_class.where(
+            scope_condition
+          ).update_all("#{position_column} = (#{position_column} + 1)")
+        end
+
+        def acts_as_list_handle_scope_change
+          return unless acts_as_list_scope_changed?
+
+          old_scope = acts_as_list_old_scope_condition
+          old_position = send("#{position_column}_was")
+          if old_position
+            acts_as_list_class.where([
+              "#{old_scope} AND #{position_column} > ?", old_position.to_i
+            ]).update_all("#{position_column} = (#{position_column} - 1)")
           end
+          self[position_column] = nil
+          @__aal_scope_changed = true
+        end
+
+        def acts_as_list_restore_position
+          return unless @__aal_scope_changed
+          update_column(position_column, bottom_position_in_list.to_i + 1)
+        end
+
+        def acts_as_list_scope_changed?
+          scope = acts_as_list_class.acts_as_list_options[:scope]
+          case scope
+          when Symbol
+            attribute_changed?(scope)
+          when Array
+            scope.any? { |attr| attribute_changed?(attr) }
+          else
+            false
+          end
+        end
+
+        def acts_as_list_old_scope_condition
+          scope = acts_as_list_class.acts_as_list_options[:scope]
+          case scope
+          when Symbol
+            val = send("#{scope}_was")
+            self.class.send(:sanitize_sql_hash_for_conditions, { scope => val })
+          when Array
+            attrs = scope.each_with_object({}) { |a, memo| memo[a] = send("#{a}_was") }
+            self.class.send(:sanitize_sql_hash_for_conditions, attrs)
+          else
+            scope_condition
+          end
+        end
+
+        def attribute_changed?(attr)
+          if respond_to?("will_save_change_to_#{attr}?")
+            send("will_save_change_to_#{attr}?")
+          elsif respond_to?("#{attr}_changed?")
+            send("#{attr}_changed?")
+          else
+            false
+          end
+        end
 
           def insert_at_position(position)
             remove_from_list

--- a/test/list_test.rb
+++ b/test/list_test.rb
@@ -263,6 +263,20 @@ class ListTest < Test::Unit::TestCase
     assert_equal 3, ListMixin.find(4).pos
   end
 
+  def test_scope_change_reorders_lists
+    item1 = ListMixin.create!(:parent_id => 10)
+    item2 = ListMixin.create!(:parent_id => 10)
+    item3 = ListMixin.create!(:parent_id => 20)
+
+    item2.update!(:parent_id => 20)
+
+    assert_equal [item1.id], ListMixin.where(:parent_id => 10).order('pos').map(&:id)
+    assert_equal [item3.id, item2.id], ListMixin.where(:parent_id => 20).order('pos').map(&:id)
+    assert_equal 1, item1.reload.pos
+    assert_equal 1, item3.reload.pos
+    assert_equal 2, item2.reload.pos
+  end
+
 end
 
 class ListSubTest < Test::Unit::TestCase


### PR DESCRIPTION
## Summary
- store acts_as_list configuration options on the model
- reposition list items when their scope attributes change
- test that scope changes automatically reorder lists

## Testing
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_6878253d631c8325a78b705c8a1ba35c