### PR TITLE
Implement swap_positions_with

### DIFF
--- a/README
+++ b/README
@@ -20,6 +20,7 @@ Example
   todo_list.last.move_higher
   todo_list.first.move_below(todo_list.last)
   todo_list.last.move_above(todo_list.first)
+  todo_list.first.swap_positions_with(todo_list.last)
 
 
 Copyright (c) 2007 David Heinemeier Hansson, released under the MIT license

--- a/lib/active_record/acts/list.rb
+++ b/lib/active_record/acts/list.rb
@@ -160,6 +160,18 @@ module ActiveRecord
                     (in_list? && self.send(position_column).to_i > item.send(position_column).to_i ? 1 : 0))
         end
 
+        # Swap this item's position with +item+ while maintaining list integrity.
+        def swap_positions_with(item)
+          return unless item && in_list? && item.in_list?
+          raise ArgumentError, 'You can only swap with an item in the same scope.' unless scope_condition == item.scope_condition
+
+          acts_as_list_class.transaction do
+            other_position = item.send(position_column)
+            item.update_attribute(position_column, send(position_column))
+            update_attribute(position_column, other_position)
+          end
+        end
+
         # Removes the item from the list.
         def remove_from_list
           if in_list?

--- a/test/list_test.rb
+++ b/test/list_test.rb
@@ -120,6 +120,12 @@ class ListTest < Test::Unit::TestCase
     assert_equal [2, 3, 1, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
   end
 
+  def test_swap_positions_with
+    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+    ListMixin.find(1).swap_positions_with(ListMixin.find(4))
+    assert_equal [4, 2, 3, 1], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+  end
+
   def test_next_prev
     assert_equal ListMixin.find(2), ListMixin.find(1).lower_item
     assert_nil ListMixin.find(1).higher_item
@@ -328,6 +334,12 @@ class ListSubTest < Test::Unit::TestCase
     assert_equal [2, 3, 1, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
   end
 
+  def test_swap_positions_with
+    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+    ListMixin.find(1).swap_positions_with(ListMixin.find(4))
+    assert_equal [4, 2, 3, 1], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+  end
+
   def test_next_prev
     assert_equal ListMixin.find(2), ListMixin.find(1).lower_item
     assert_nil ListMixin.find(1).higher_item
@@ -446,6 +458,12 @@ class ArrayScopeListTest < Test::Unit::TestCase
     assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
     ArrayScopeListMixin.find(1).move_below(ArrayScopeListMixin.find(3))
     assert_equal [2, 3, 1, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+  end
+
+  def test_swap_positions_with
+    assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+    ArrayScopeListMixin.find(1).swap_positions_with(ArrayScopeListMixin.find(4))
+    assert_equal [4, 2, 3, 1], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
   end
 
   def test_next_prev


### PR DESCRIPTION
## Summary
- add `swap_positions_with` list operation
- document swapping positions in the README
- test swap behavior across list, subclassed lists and arrayscoped lists

## Testing
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_6878278308008325a312c86df2d68eaf